### PR TITLE
Pin markupsafe to fix import error for soft_unicode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask-SQLAlchemy~=2.4
 psycopg2-binary==2.8.6
 python-dateutil==2.8.2
 pytz==2021.1
+markupsafe==2.0.1


### PR DESCRIPTION
## Description
I am demo-ing this to my students this Saturday and ran into a dependency issue. Looks like there was a breaking [change](https://github.com/pallets/markupsafe/issues/286) to the markupsafe library and soft_unicode is no longer importable